### PR TITLE
display username and usericon as slack native format

### DIFF
--- a/scripts/wormhole.coffee
+++ b/scripts/wormhole.coffee
@@ -24,7 +24,9 @@ module.exports = (robot) ->
         .then((conn) ->
           conn.createChannel().then((ch) ->
             ex = 'topic.wormhole'
-            username = res.message.user.name
+            username = res.message.user.profile.display_name ||
+                       res.message.user.profile.real_name ||
+                       res.message.user.name
             key = process.env.HUBOT_WORMHOLE_ROUTING_KEY
 
             ch.assertExchange(ex, 'topic', {durable: false})

--- a/scripts/wormhole.coffee
+++ b/scripts/wormhole.coffee
@@ -27,10 +27,12 @@ module.exports = (robot) ->
             username = res.message.user.profile.display_name ||
                        res.message.user.profile.real_name ||
                        res.message.user.name
+            icon = res.message.user.profile.image_192
             key = process.env.HUBOT_WORMHOLE_ROUTING_KEY
+            payload = { username: username, icon_url: icon, text: res.message.text, as_user: false }
 
             ch.assertExchange(ex, 'topic', {durable: false})
-            ch.publish(ex, key, Buffer.from("#{username}「 #{res.message} 」"))
+            ch.publish(ex, key, Buffer.from(JSON.stringify(payload)))
           )
         ).catch((reason) ->
           res.send("Error: #{reason}")
@@ -40,7 +42,7 @@ module.exports = (robot) ->
     amqp_cb = require('amqplib/callback_api')
     amqp_cb.connect("amqp://#{user}:#{pass}@#{url}", (err, conn) ->
       room = process.env.HUBOT_EXHALE_ROOM || "wormhole"
-      send = (msg) -> robot.messageRoom room, msg
+      send = (msg) -> robot.send {room: room}, msg
       if err
         send "Error: #{err}"
       else
@@ -59,7 +61,7 @@ module.exports = (robot) ->
                   ch.bindQueue(q.queue, ex, key)
 
                 ch.consume(q.queue, (msg) ->
-                  send(msg.content.toString())
+                  send(JSON.parse(msg.content.toString()))
                   ch.ack(msg)
                 )
             )


### PR DESCRIPTION
* usernameの表示優先順位をSlackと同じように変更
  * display_name -> real_name -> username
* ユーザーのアイコンと名前がそのままSlackフォーマットで表示されるように変更(timelinerっぽく)

![2018-02-27 12 56 56](https://user-images.githubusercontent.com/4261848/36709926-02efe424-1bbe-11e8-98e5-32907aea9f7a.png)
